### PR TITLE
Disbale WARNING: Unsupported  httpclient version 2.6

### DIFF
--- a/lib/winrm/http/auth.rb
+++ b/lib/winrm/http/auth.rb
@@ -25,7 +25,7 @@ def validate_patch
   # for encrypt/decrypt as described below.
   # Add few restriction to make sure the patched methods are still
   # available, but still give a way to consciously use later versions
-  PatchAssertions.assert_major_version("httpclient", 2.5, "USE_HTTPCLIENT_MAJOR")
+  PatchAssertions.assert_major_version("httpclient", 2.6, "USE_HTTPCLIENT_MAJOR")
   PatchAssertions.assert_arity_of_patched_method(HTTPClient::WWWAuth, "filter_request", 1)
   PatchAssertions.assert_arity_of_patched_method(HTTPClient::WWWAuth, "filter_response", 2)
   PatchAssertions.assert_arity_of_patched_method(HTTPClient::SSPINegotiateAuth, "set", -1)


### PR DESCRIPTION
Added changes to disable WARNING: Unsupported version of httpclient for httpclient 2.6 